### PR TITLE
Fix bugs and code quality issues found in audit

### DIFF
--- a/cmd/certtool/certtool.go
+++ b/cmd/certtool/certtool.go
@@ -33,10 +33,10 @@ var (
 	ca = flag.Bool("ca", false, "Generates a root certificate. Use this to establish a chain of trust with derived certificates.")
 
 	country            = flag.String("country", "US", "CountryName field of the certificate attribute.")
-	organization       = flag.String("organization", "gowebserver", "CountryName field of the certificate attribute.")
-	organizationalUnit = flag.String("organizational-unit", "gows", "CountryName field of the certificate attribute.")
-	locality           = flag.String("locality", "Seattle", "CountryName field of the certificate attribute.")
-	province           = flag.String("province", "WA", "CountryName field of the certificate attribute.")
+	organization       = flag.String("organization", "gowebserver", "OrganizationName field of the certificate attribute.")
+	organizationalUnit = flag.String("organizational-unit", "gows", "OrganizationalUnit field of the certificate attribute.")
+	locality           = flag.String("locality", "Seattle", "Locality field of the certificate attribute.")
+	province           = flag.String("province", "WA", "Province/StateOrProvinceName field of the certificate attribute.")
 
 	hostnames = flag.String("hostnames", "", "Comma separated list of hostnames.")
 	keyType   = flag.String("key-type", "RSA-2048", "Type of key to generate. (default: RSA-2048)")

--- a/pkg/gowebserver/config.go
+++ b/pkg/gowebserver/config.go
@@ -136,7 +136,9 @@ func (c *Config) String() string {
 	if err := e.Encode(c); err != nil {
 		return err.Error()
 	}
-	e.Close()
+	if err := e.Close(); err != nil {
+		return err.Error()
+	}
 	return b.String()
 }
 

--- a/pkg/gowebserver/customindex.go
+++ b/pkg/gowebserver/customindex.go
@@ -165,7 +165,7 @@ func (c *customIndexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			rdf, ok := f.(fs.ReadDirFile)
 			if ok {
 				span.SetAttributes(attribute.Bool("custom_directory_list", true))
-				readDirSpan.AddEvent("")
+				readDirSpan.AddEvent("read directory entries")
 				now := time.Now()
 				entries, err := rdf.ReadDir(-1)
 				span.SetAttributes(attribute.Int("num_entries", len(entries)))

--- a/pkg/gowebserver/filesystem_git.go
+++ b/pkg/gowebserver/filesystem_git.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !aix
-// +build !aix
 
 package gowebserver
 

--- a/pkg/gowebserver/filesystem_git_unsupported.go
+++ b/pkg/gowebserver/filesystem_git_unsupported.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build aix
-// +build aix
 
 package gowebserver
 

--- a/pkg/gowebserver/filetypes.go
+++ b/pkg/gowebserver/filetypes.go
@@ -15,10 +15,11 @@
 package gowebserver
 
 import (
-	"log"
 	"mime"
 	"path/filepath"
 	"strings"
+
+	"go.uber.org/zap"
 )
 
 var (
@@ -136,6 +137,6 @@ func nameToIconClass(isDir bool, name string) string {
 		}
 	}
 
-	log.Printf("%s > %s", ext, mimeType)
+	zap.S().Debugf("unknown extension %q with MIME type %q", ext, mimeType)
 	return "unknown"
 }

--- a/pkg/gowebserver/gowebserver.go
+++ b/pkg/gowebserver/gowebserver.go
@@ -69,7 +69,9 @@ func runApplication(wait func()) error {
 
 	logger.Sugar().Debug(conf)
 
-	checkError(createCertificate(conf))
+	if err := createCertificate(conf); err != nil {
+		return err
+	}
 
 	httpServer, err := New(conf)
 	if err != nil {

--- a/pkg/gowebserver/index.go
+++ b/pkg/gowebserver/index.go
@@ -16,12 +16,13 @@ package gowebserver
 
 import (
 	"bytes"
-	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	_ "embed"
+
+	"go.uber.org/zap"
 )
 
 var (
@@ -59,7 +60,7 @@ func newIndexHTTPHandler(servePaths []string, modern bool) (*indexHTTPHandler, e
 		HasNonMediaEntry: true,
 	}
 
-	log.Printf("ROOT: %+v", params)
+	zap.S().Debugf("index root: %+v", params)
 	if err := executeTemplate(templateHTML, params, w); err != nil {
 		return nil, err
 	}

--- a/pkg/gowebserver/monitoring.go
+++ b/pkg/gowebserver/monitoring.go
@@ -117,11 +117,11 @@ func setupMonitoring(m Monitoring) (*monitoringContext, error) {
 
 func newPrometheusExporter(m Monitoring, r *resource.Resource) (*otelprom.Exporter, *sdkmetric.MeterProvider, http.Handler, error) {
 	registry := prometheus.NewRegistry()
-	registry.Register(collectors.NewBuildInfoCollector())
-	registry.Register(collectors.NewGoCollector())
-	registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{
+	logError(registry.Register(collectors.NewBuildInfoCollector()))
+	logError(registry.Register(collectors.NewGoCollector()))
+	logError(registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{
 		ReportErrors: true,
-	}))
+	})))
 
 	prometheusExporter, err := otelprom.New(otelprom.WithRegisterer(registry))
 	if err != nil {
@@ -162,6 +162,9 @@ func (m *monitoringContext) shutdown() {
 	}
 	ctx := context.Background()
 	if m.promProvider != nil {
+		if mp, ok := m.promProvider.(*sdkmetric.MeterProvider); ok {
+			mp.Shutdown(ctx)
+		}
 		m.promProvider = nil
 	}
 	if m.promExporter != nil {

--- a/pkg/gowebserver/upload.go
+++ b/pkg/gowebserver/upload.go
@@ -17,15 +17,13 @@ package gowebserver
 // https://astaxie.gitbooks.io/build-web-application-with-golang/content/en/04.5.html
 // http://sanatgersappa.blogspot.com/2013/03/handling-multiple-file-uploads-in-go.html
 import (
-	"crypto/md5"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
-	"time"
 
 	_ "embed"
 
@@ -42,7 +40,9 @@ var (
 )
 
 const (
-	uploadFileFormName = "gowebserveruploadfile[]"
+	uploadFileFormName    = "gowebserveruploadfile[]"
+	uploadTokenCookieName = "gowebserver_csrf"
+	uploadTokenFormField  = "token"
 )
 
 type uploadHTTPHandler struct {
@@ -70,10 +70,19 @@ func (uh *uploadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := zap.S().With("url", r.URL)
 
 	if r.Method == "GET" {
-		crutime := time.Now().Unix()
-		h := md5.New()
-		io.WriteString(h, strconv.FormatInt(crutime, 10))
-		token := fmt.Sprintf("%x", h.Sum(nil))
+		tokenBytes := make([]byte, 16)
+		if _, err := rand.Read(tokenBytes); err != nil {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+			return
+		}
+		token := fmt.Sprintf("%x", tokenBytes)
+		http.SetCookie(w, &http.Cookie{
+			Name:     uploadTokenCookieName,
+			Value:    token,
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+			Path:     "/",
+		})
 
 		var params = struct {
 			UploadHTTPPath     string
@@ -87,6 +96,13 @@ func (uh *uploadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		var resp uploadResponse
 
+		csrfCookie, cookieErr := r.Cookie(uploadTokenCookieName)
+		if cookieErr != nil || csrfCookie.Value == "" {
+			resp.Error = fmt.Errorf("request rejected: missing CSRF token")
+			writeUploadResponse(w, resp, logger, span)
+			return
+		}
+
 		ctx, childSpan := uploadTracer.Start(ctx, "ParseMultipartForm")
 		if err := r.ParseMultipartForm(32 << 20); err != nil {
 			resp.Error = fmt.Errorf("InternalError: cannot parse multi-part form")
@@ -94,8 +110,14 @@ func (uh *uploadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			childSpan.End()
 			return
 		}
-
 		childSpan.End()
+
+		if formToken := r.FormValue(uploadTokenFormField); formToken == "" || formToken != csrfCookie.Value {
+			resp.Error = fmt.Errorf("request rejected: invalid CSRF token")
+			writeUploadResponse(w, resp, logger, span)
+			return
+		}
+
 		m := r.MultipartForm
 		files := m.File[uploadFileFormName]
 		for i := range files {
@@ -165,19 +187,19 @@ func newUploadHandler(mc *monitoringContext, uploadHTTPPath string, uploadDirect
 }
 
 func writeUploadResponse(w http.ResponseWriter, resp uploadResponse, logger *zap.SugaredLogger, span trace.Span) {
-	if resp.Error != nil {
-		logger.With("error", resp.Error).Warn("Upload error")
-		w.WriteHeader(http.StatusBadRequest)
-		span.RecordError(resp.Error)
-	} else {
-		logger.Debug("Upload Successful")
-	}
 	data, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, "Malformed server response.", http.StatusInternalServerError)
 		logger.With("error", err).Warn("Cannot marshal upload JSON response")
 		return
 	}
-	w.Header().Add("Content-Type", "application/json")
+	w.Header().Set("Content-Type", "application/json")
+	if resp.Error != nil {
+		logger.With("error", resp.Error).Warn("Upload error")
+		span.RecordError(resp.Error)
+		w.WriteHeader(http.StatusBadRequest)
+	} else {
+		logger.Debug("Upload Successful")
+	}
 	w.Write(data)
 }

--- a/pkg/gowebserver/upload_test.go
+++ b/pkg/gowebserver/upload_test.go
@@ -60,17 +60,42 @@ func TestUpload(t *testing.T) {
 
 	baseURL, close := serveAsync(t, cfg)
 	defer close()
+
+	ctx := context.Background()
+	hc := &http.Client{}
+
+	// GET the upload form to acquire the CSRF cookie and token.
+	getReq, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/upload", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	getResp, err := hc.Do(getReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer getResp.Body.Close()
+
+	var csrfToken string
+	for _, cookie := range getResp.Cookies() {
+		if cookie.Name == uploadTokenCookieName {
+			csrfToken = cookie.Value
+			break
+		}
+	}
+	if csrfToken == "" {
+		t.Fatal("CSRF token cookie not set by upload GET handler")
+	}
+
 	fp, err := os.Open(zipPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
-	req, err := newUploadFormRequest(ctx, baseURL+"/upload", "test.zip", fp, map[string]string{})
+	req, err := newUploadFormRequest(ctx, baseURL+"/upload", "test.zip", fp, map[string]string{uploadTokenFormField: csrfToken})
 	if err != nil {
 		t.Error(err)
 	}
-	hc := &http.Client{}
+	req.AddCookie(&http.Cookie{Name: uploadTokenCookieName, Value: csrfToken})
 	resp, err := hc.Do(req)
 	if err != nil {
 		t.Error(err)

--- a/pkg/httpprobe/httpprobe.go
+++ b/pkg/httpprobe/httpprobe.go
@@ -62,6 +62,7 @@ func Probe(args Args) error {
 			Message: fmt.Sprintf("%s is not available, %v", u, err),
 		}
 	}
+	defer resp.Body.Close()
 
 	if 200 <= resp.StatusCode && resp.StatusCode < 300 {
 		return nil


### PR DESCRIPTION
- upload: set Content-Type before WriteHeader so error responses include the header
- upload: replace MD5(timestamp) CSRF token with crypto/rand, validate via cookie double-submit
- upload: fix TestUpload to follow the CSRF GET→POST flow
- httpprobe: close response body to avoid connection leak
- gowebserver: propagate createCertificate error instead of swallowing it
- monitoring: call promProvider.Shutdown via type assertion on cleanup
- monitoring: log registry.Register errors instead of ignoring them
- certtool: fix flag descriptions for organization, organizationalUnit, locality, province
- filesystem_git: remove redundant deprecated // +build constraints
- config: check yaml encoder Close() error in Config.String()
- customindex: replace empty OTel event name with descriptive string
- filetypes, index: replace stdlib log.Printf with zap.S().Debugf