### PR TITLE
Improve flag descriptions across certtool and gowebserver

### DIFF
--- a/cmd/certtool/certtool.go
+++ b/cmd/certtool/certtool.go
@@ -32,14 +32,14 @@ var (
 
 	ca = flag.Bool("ca", false, "Generates a root certificate. Use this to establish a chain of trust with derived certificates.")
 
-	country            = flag.String("country", "US", "CountryName field of the certificate attribute.")
-	organization       = flag.String("organization", "gowebserver", "CountryName field of the certificate attribute.")
-	organizationalUnit = flag.String("organizational-unit", "gows", "CountryName field of the certificate attribute.")
-	locality           = flag.String("locality", "Seattle", "CountryName field of the certificate attribute.")
-	province           = flag.String("province", "WA", "CountryName field of the certificate attribute.")
+	country            = flag.String("country", "US", "Country (C) field of the X.509 certificate subject (e.g. US, CA, GB).")
+	organization       = flag.String("organization", "gowebserver", "Organization (O) field of the X.509 certificate subject.")
+	organizationalUnit = flag.String("organizational-unit", "gows", "Organizational Unit (OU) field of the X.509 certificate subject.")
+	locality           = flag.String("locality", "Seattle", "Locality (L) field of the X.509 certificate subject, typically the city name.")
+	province           = flag.String("province", "WA", "Province or state (ST) field of the X.509 certificate subject.")
 
-	hostnames = flag.String("hostnames", "", "Comma separated list of hostnames.")
-	keyType   = flag.String("key-type", "RSA-2048", "Type of key to generate. (default: RSA-2048)")
+	hostnames = flag.String("hostnames", "", "Comma-separated list of hostnames and IP addresses to include as Subject Alternative Names (SANs).")
+	keyType   = flag.String("key-type", "RSA-2048", "Key algorithm and length. Supported values: RSA-2048, RSA-4096, ECDSA-224, ECDSA-256, ECDSA-384, ECDSA-521.")
 
 	parentPublicCertificate = flag.String("parent-public-certificate", "", "(optional) Parent public certificate. If set, the output certificate will trust the parent.")
 	parentPrivateKey        = flag.String("parent-private-key", "", "(optional) Parent private key. Required if -parent-public-certificate is set, private key for the parent public certificate.")

--- a/pkg/gowebserver/config.go
+++ b/pkg/gowebserver/config.go
@@ -51,16 +51,16 @@ var (
 	privateKeyFilePathFlag      = flag.String("https.certificate.privatekey", "web.key", "Private key for HTTPS serving.")
 	certificateFilePathFlag     = flag.String("https.certificate.path", "web.cert", "Certificate to host HTTPS with.")
 	certHostsFlag               = flag.String("https.certificate.hosts", "", "Comma-separated hostnames and IPs to generate a certificate for.")
-	validDurationFlag           = flag.Duration("https.certificate.duration", time.Hour*43800, "Lifespan of the certificate. (default: 5 years)")
+	validDurationFlag           = flag.Duration("https.certificate.duration", time.Hour*43800, "Validity period of the generated certificate; the default 43800h is approximately 5 years.")
 	forceOverwriteCertFlag      = flag.Bool("https.certificate.forceoverwrite", false, "Force overwrite existing certificates if they already exist.")
 
 	// Monitoring Flags
-	monitoringDebugEndpointFlag = flag.String("monitoring.debugendpoint", "/debug", "The URL path debugging.")
+	monitoringDebugEndpointFlag = flag.String("monitoring.debugendpoint", "/debug", "URL path prefix for pprof and OpenTelemetry tracez debug endpoints.")
 	monitoringTraceURIFlag      = flag.String("monitoring.trace.uri", "", "OTLP HTTP endpoint URL for tracing (e.g. http://host:4318).")
 	monitoringMetricsPath       = flag.String("monitoring.metrics.path", "/metrics", "The URL path for exporting server metrics for Prometheus monitoring.")
 
-	enhancedListFlag = flag.Bool("enhancedindex", false, "Enable enhanced index.")
-	debugFlag        = flag.Bool("debug", false, "Enable debug HTTP methods.")
+	enhancedListFlag = flag.Bool("enhancedindex", false, "Enable the enhanced directory listing UI with file previews and sorting.")
+	debugFlag        = flag.Bool("debug", false, "Expose the /diediedie shutdown endpoint for testing.")
 
 	version = "UNKNOWN"
 )


### PR DESCRIPTION
certtool: fix copy-paste errors where organization, organizational-unit, locality, and province all read "CountryName field of the certificate attribute." Add proper X.509 short names (O, OU, L, ST), expand hostnames description to mention SANs and IP addresses, and list valid key-type values instead of duplicating the default value.

gowebserver: fix broken grammar in monitoring.debugendpoint description ("The URL path debugging." → names the pprof and tracez endpoints it serves). Replace the redundant "(default: 5 years)" annotation on https.certificate.duration with an inline explanation of the raw 43800h value. Replace vague "Enable enhanced index." with a description of the custom UI with previews and sorting. Replace vague "Enable debug HTTP methods." with the actual /diediedie shutdown endpoint it exposes.