### PR TITLE
Add missing error handling across gowebserver package

### DIFF
--- a/pkg/gowebserver/httpserver.go
+++ b/pkg/gowebserver/httpserver.go
@@ -164,7 +164,9 @@ func (ws *webServerImpl) Serve(wait func()) error {
 
 	defer func() {
 		for _, cleanup := range allCleanups {
-			cleanup()
+			if err := cleanup(); err != nil {
+				zap.S().With("error", err).Error("cleanup error")
+			}
 		}
 	}()
 

--- a/pkg/gowebserver/index.go
+++ b/pkg/gowebserver/index.go
@@ -16,12 +16,13 @@ package gowebserver
 
 import (
 	"bytes"
-	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	_ "embed"
+
+	"go.uber.org/zap"
 )
 
 var (
@@ -59,7 +60,7 @@ func newIndexHTTPHandler(servePaths []string, modern bool) (*indexHTTPHandler, e
 		HasNonMediaEntry: true,
 	}
 
-	log.Printf("ROOT: %+v", params)
+	zap.S().With("params", params).Debug("newIndexHTTPHandler")
 	if err := executeTemplate(templateHTML, params, w); err != nil {
 		return nil, err
 	}
@@ -71,5 +72,7 @@ func newIndexHTTPHandler(servePaths []string, modern bool) (*indexHTTPHandler, e
 
 func (h *indexHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "text/html")
-	w.Write(h.page)
+	if _, err := w.Write(h.page); err != nil {
+		zap.S().With("error", err).Warn("cannot write index response")
+	}
 }

--- a/pkg/gowebserver/monitoring.go
+++ b/pkg/gowebserver/monitoring.go
@@ -33,6 +33,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 )
 
 func setupMonitoring(m Monitoring) (*monitoringContext, error) {
@@ -117,11 +118,17 @@ func setupMonitoring(m Monitoring) (*monitoringContext, error) {
 
 func newPrometheusExporter(m Monitoring, r *resource.Resource) (*otelprom.Exporter, *sdkmetric.MeterProvider, http.Handler, error) {
 	registry := prometheus.NewRegistry()
-	registry.Register(collectors.NewBuildInfoCollector())
-	registry.Register(collectors.NewGoCollector())
-	registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{
+	if err := registry.Register(collectors.NewBuildInfoCollector()); err != nil {
+		return nil, nil, nil, err
+	}
+	if err := registry.Register(collectors.NewGoCollector()); err != nil {
+		return nil, nil, nil, err
+	}
+	if err := registry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{
 		ReportErrors: true,
-	}))
+	})); err != nil {
+		return nil, nil, nil, err
+	}
 
 	prometheusExporter, err := otelprom.New(otelprom.WithRegisterer(registry))
 	if err != nil {
@@ -165,10 +172,14 @@ func (m *monitoringContext) shutdown() {
 		m.promProvider = nil
 	}
 	if m.promExporter != nil {
-		m.promExporter.Shutdown(ctx)
+		if err := m.promExporter.Shutdown(ctx); err != nil {
+			zap.S().With("error", err).Error("cannot shutdown prometheus exporter")
+		}
 		m.promExporter = nil
 	}
 	if m.tp != nil {
-		m.tp.Shutdown(ctx)
+		if err := m.tp.Shutdown(ctx); err != nil {
+			zap.S().With("error", err).Error("cannot shutdown trace provider")
+		}
 	}
 }

--- a/pkg/gowebserver/upload.go
+++ b/pkg/gowebserver/upload.go
@@ -180,5 +180,7 @@ func writeUploadResponse(w http.ResponseWriter, resp uploadResponse, logger *zap
 		return
 	}
 	w.Header().Add("Content-Type", "application/json")
-	w.Write(data)
+	if _, err := w.Write(data); err != nil {
+		logger.With("error", err).Warn("cannot write upload response")
+	}
 }


### PR DESCRIPTION
- Propagate registry.Register() errors in newPrometheusExporter
- Log Shutdown() errors for prometheus exporter and trace provider
- Log cleanup errors in Serve() deferred cleanup loop
- Check w.Write() errors in writeUploadResponse and indexHTTPHandler
- Replace stray log.Printf with zap in newIndexHTTPHandler