### PR TITLE
Add CSRF protection to upload endpoint via double-submit cookie pattern

### DIFF
--- a/pkg/gowebserver/upload.go
+++ b/pkg/gowebserver/upload.go
@@ -17,15 +17,15 @@ package gowebserver
 // https://astaxie.gitbooks.io/build-web-application-with-golang/content/en/04.5.html
 // http://sanatgersappa.blogspot.com/2013/03/handling-multiple-file-uploads-in-go.html
 import (
-	"crypto/md5"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
-	"time"
 
 	_ "embed"
 
@@ -43,6 +43,7 @@ var (
 
 const (
 	uploadFileFormName = "gowebserveruploadfile[]"
+	uploadCSRFCookie   = "csrf_token"
 )
 
 type uploadHTTPHandler struct {
@@ -62,6 +63,14 @@ const (
 	uploadTraceName = "uploadHTTPHandler"
 )
 
+func generateCSRFToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
 func (uh *uploadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	uploadTracer := uh.tp.Tracer(uploadTraceName)
 	ctx, span := uploadTracer.Start(r.Context(), r.Method)
@@ -70,10 +79,18 @@ func (uh *uploadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	logger := zap.S().With("url", r.URL)
 
 	if r.Method == "GET" {
-		crutime := time.Now().Unix()
-		h := md5.New()
-		io.WriteString(h, strconv.FormatInt(crutime, 10))
-		token := fmt.Sprintf("%x", h.Sum(nil))
+		token, err := generateCSRFToken()
+		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name:     uploadCSRFCookie,
+			Value:    token,
+			Path:     uh.uploadHTTPPath,
+			SameSite: http.SameSiteStrictMode,
+			HttpOnly: true,
+		})
 
 		var params = struct {
 			UploadHTTPPath     string
@@ -88,6 +105,12 @@ func (uh *uploadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		var resp uploadResponse
 
+		cookie, cookieErr := r.Cookie(uploadCSRFCookie)
+		if cookieErr != nil {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+
 		ctx, childSpan := uploadTracer.Start(ctx, "ParseMultipartForm")
 		if err := r.ParseMultipartForm(32 << 20); err != nil {
 			resp.Error = fmt.Errorf("InternalError: cannot parse multi-part form")
@@ -95,8 +118,13 @@ func (uh *uploadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			childSpan.End()
 			return
 		}
-
 		childSpan.End()
+
+		if subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(r.FormValue("token"))) != 1 {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+
 		m := r.MultipartForm
 		files := m.File[uploadFileFormName]
 		for i := range files {

--- a/pkg/gowebserver/upload_test.go
+++ b/pkg/gowebserver/upload_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/http/cookiejar"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,6 +38,49 @@ func TestUploadHTML(t *testing.T) {
 	}
 }
 
+func newUploadServer(t *testing.T) (string, func()) {
+	t.Helper()
+	tmpDir, closeDir, err := createTempDirectory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &Config{
+		Serve: []Serve{
+			{Source: tmpDir, Endpoint: "/"},
+		},
+		Upload: Serve{
+			Source:   tmpDir,
+			Endpoint: "/upload",
+		},
+	}
+	baseURL, closeServer := serveAsync(t, cfg)
+	return baseURL, func() {
+		closeServer()
+		closeDir()
+	}
+}
+
+func getUploadCSRFToken(t *testing.T, uploadURL string, hc *http.Client) string {
+	t.Helper()
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uploadURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name == uploadCSRFCookie {
+			return cookie.Value
+		}
+	}
+	t.Fatal("no csrf_token cookie in GET /upload response")
+	return ""
+}
+
 func TestUpload(t *testing.T) {
 	zipPath := gowsTesting.MustZipFilePath(t)
 	tmpDir, close, err := createTempDirectory()
@@ -47,10 +91,7 @@ func TestUpload(t *testing.T) {
 
 	cfg := &Config{
 		Serve: []Serve{
-			{
-				Source:   tmpDir,
-				Endpoint: "/",
-			},
+			{Source: tmpDir, Endpoint: "/"},
 		},
 		Upload: Serve{
 			Source:   tmpDir,
@@ -60,17 +101,24 @@ func TestUpload(t *testing.T) {
 
 	baseURL, close := serveAsync(t, cfg)
 	defer close()
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hc := &http.Client{Jar: jar}
+	ctx := context.Background()
+
+	csrfToken := getUploadCSRFToken(t, baseURL+"/upload", hc)
+
 	fp, err := os.Open(zipPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	ctx := context.Background()
-	req, err := newUploadFormRequest(ctx, baseURL+"/upload", "test.zip", fp, map[string]string{})
+	req, err := newUploadFormRequest(ctx, baseURL+"/upload", "test.zip", fp, map[string]string{"token": csrfToken})
 	if err != nil {
 		t.Error(err)
 	}
-	hc := &http.Client{}
 	resp, err := hc.Do(req)
 	if err != nil {
 		t.Error(err)
@@ -102,6 +150,78 @@ func TestUpload(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Errorf("http status code is '%d'", resp.StatusCode)
 	}
+}
+
+func TestUploadCSRFProtection(t *testing.T) {
+	zipPath := gowsTesting.MustZipFilePath(t)
+
+	baseURL, close := newUploadServer(t)
+	defer close()
+
+	t.Run("no_cookie_no_token", func(t *testing.T) {
+		fp, err := os.Open(zipPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fp.Close()
+		req, err := newUploadFormRequest(context.Background(), baseURL+"/upload", "test.zip", fp, map[string]string{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected %d Forbidden, got %d", http.StatusForbidden, resp.StatusCode)
+		}
+	})
+
+	t.Run("cookie_present_but_token_mismatch", func(t *testing.T) {
+		fp, err := os.Open(zipPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fp.Close()
+		req, err := newUploadFormRequest(context.Background(), baseURL+"/upload", "test.zip", fp, map[string]string{"token": "aaaaaaaabbbbbbbbccccccccdddddddd"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.AddCookie(&http.Cookie{Name: uploadCSRFCookie, Value: "xxxxxxxxyyyyyyyyzzzzzzzzwwwwwwww"})
+		resp, err := (&http.Client{}).Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusForbidden {
+			t.Errorf("expected %d Forbidden, got %d", http.StatusForbidden, resp.StatusCode)
+		}
+	})
+
+	t.Run("valid_csrf_flow", func(t *testing.T) {
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		hc := &http.Client{Jar: jar}
+		csrfToken := getUploadCSRFToken(t, baseURL+"/upload", hc)
+
+		fp, err := os.Open(zipPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer fp.Close()
+		req, err := newUploadFormRequest(context.Background(), baseURL+"/upload", "test.zip", fp, map[string]string{"token": csrfToken})
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := hc.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected %d OK, got %d", http.StatusOK, resp.StatusCode)
+		}
+	})
 }
 
 func sha256File(tb testing.TB, localPath string) string {


### PR DESCRIPTION
- Replace predictable md5(timestamp) token with crypto/rand (32 bytes, hex-encoded)
- Set SameSite=Strict HttpOnly cookie on GET so the token is bound to the session
- Validate cookie vs form token on POST using constant-time comparison; reject with 403 if missing or mismatched
- Update TestUpload to acquire CSRF token via GET before uploading
- Add TestUploadCSRFProtection covering missing cookie, mismatched token, and valid flow