### PR TITLE
Fix TLS cert SAN to include local hostname and IPs for iCloud Private…

### DIFF
--- a/pkg/gowebserver/gowebserver.go
+++ b/pkg/gowebserver/gowebserver.go
@@ -16,7 +16,9 @@ package gowebserver
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"strings"
 
 	"github.com/jeremyje/gomain"
 	"github.com/jeremyje/gowebserver/v2/pkg/certtool"
@@ -79,6 +81,48 @@ func runApplication(wait func()) error {
 	return httpServer.Serve(wait)
 }
 
+// buildCertificateHostnames returns the list of hostnames and IPs to include in the TLS
+// certificate SAN. It merges user-specified hosts with the machine's hostname and all
+// non-loopback local IPs so that the auto-generated cert is valid for any local-network
+// address the server may be reached at (e.g. "server2", "192.168.1.10").
+func buildCertificateHostnames(conf *Config) []string {
+	seen := map[string]bool{}
+	var hostnames []string
+
+	add := func(h string) {
+		h = strings.TrimSpace(h)
+		if h != "" && !seen[h] {
+			seen[h] = true
+			hostnames = append(hostnames, h)
+		}
+	}
+
+	for _, h := range strings.Split(conf.HTTPS.Certificate.CertificateHosts, ",") {
+		add(h)
+	}
+
+	if hostname, err := os.Hostname(); err == nil {
+		add(hostname)
+	}
+
+	if addrs, err := net.InterfaceAddrs(); err == nil {
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip != nil && !ip.IsLoopback() {
+				add(ip.String())
+			}
+		}
+	}
+
+	return hostnames
+}
+
 func createCertificate(conf *Config) error {
 	dir, err := os.Getwd()
 	zap.S().With("certificate", conf.HTTPS.Certificate, "directory", dir, "error", err).Debug("createCertificate")
@@ -115,6 +159,7 @@ func createCertificate(conf *Config) error {
 			},
 			Validity:      conf.HTTPS.Certificate.CertificateValidDuration,
 			CA:            false,
+			Hostnames:     buildCertificateHostnames(conf),
 			ParentKeyPair: parentKP,
 		},
 			conf.HTTPS.Certificate.CertificateFilePath,

--- a/pkg/gowebserver/gowebserver_test.go
+++ b/pkg/gowebserver/gowebserver_test.go
@@ -15,6 +15,7 @@
 package gowebserver
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,6 +25,98 @@ import (
 	gomainTesting "github.com/jeremyje/gomain/testing"
 	"github.com/jeremyje/gowebserver/v2/pkg/certtool"
 )
+
+func TestBuildCertificateHostnames(t *testing.T) {
+	localHostname, _ := os.Hostname()
+
+	tests := []struct {
+		name      string
+		hosts     string
+		mustHave  []string
+		mustNotHave []string
+	}{
+		{
+			name:     "empty hosts includes machine hostname and local IPs",
+			hosts:    "",
+			mustHave: []string{localHostname},
+		},
+		{
+			name:     "explicit hosts are included",
+			hosts:    "myserver,10.0.0.1",
+			mustHave: []string{"myserver", "10.0.0.1", localHostname},
+		},
+		{
+			name:        "loopback excluded from auto-detection",
+			hosts:       "",
+			mustNotHave: []string{"::1"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := &Config{
+				HTTPS: HTTPS{
+					Certificate: Certificate{
+						CertificateHosts: tc.hosts,
+					},
+				},
+			}
+			got := buildCertificateHostnames(conf)
+			gotSet := map[string]bool{}
+			for _, h := range got {
+				gotSet[h] = true
+			}
+
+			for _, want := range tc.mustHave {
+				if !gotSet[want] {
+					t.Errorf("expected %q in hostnames %v", want, got)
+				}
+			}
+			for _, unwanted := range tc.mustNotHave {
+				if gotSet[unwanted] {
+					t.Errorf("did not expect %q in hostnames %v", unwanted, got)
+				}
+			}
+
+			// No duplicates
+			seen := map[string]bool{}
+			for _, h := range got {
+				if seen[h] {
+					t.Errorf("duplicate hostname %q in %v", h, got)
+				}
+				seen[h] = true
+			}
+		})
+	}
+
+	// Verify the result is usable for cert generation: all non-loopback local IPs
+	// should appear so the cert is valid for any local-network address.
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		t.Skip("cannot get interface addresses:", err)
+	}
+	conf := &Config{HTTPS: HTTPS{Certificate: Certificate{}}}
+	got := buildCertificateHostnames(conf)
+	gotSet := map[string]bool{}
+	for _, h := range got {
+		gotSet[h] = true
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip == nil || ip.IsLoopback() {
+			continue
+		}
+		if !gotSet[ip.String()] {
+			t.Errorf("local IP %s missing from cert hostnames %v", ip, got)
+		}
+	}
+}
 
 func TestConfigLogger(t *testing.T) {
 	for _, verbose := range []bool{false, true} {


### PR DESCRIPTION
… Relay compatibility

Auto-generated certificates only included localhost/127.0.0.1 in the SAN, causing HTTPS to fail when accessed via the machine's network hostname (e.g. "server2") or LAN IP. This made iCloud Private Relay unable to protect the connection. Now the cert includes the machine hostname, all non-loopback interface IPs, and any user-specified hosts — making HTTPS valid for any local-network address. Also wires up the previously unused CertificateHosts config field.