### PR TITLE
Harden file permissions and disable debug endpoints by default

### DIFF
--- a/pkg/certtool/certtool.go
+++ b/pkg/certtool/certtool.go
@@ -421,15 +421,15 @@ func GenerateAndWriteKeyPair(args *Args, publicCertificateFile string, privateKe
 }
 
 func WriteKeyPair(kp *KeyPair, publicCertificateFile string, privateKeyFile string) error {
-	if err := writeFile(publicCertificateFile, kp.PublicCertificate); err != nil {
+	if err := writeFile(publicCertificateFile, kp.PublicCertificate, 0644); err != nil {
 		return err
 	}
-	if err := writeFile(privateKeyFile, kp.PrivateKey); err != nil {
+	if err := writeFile(privateKeyFile, kp.PrivateKey, 0600); err != nil {
 		return err
 	}
 	return nil
 }
 
-func writeFile(fileName string, data []byte) error {
-	return os.WriteFile(fileName, data, 0644)
+func writeFile(fileName string, data []byte, mode os.FileMode) error {
+	return os.WriteFile(fileName, data, mode)
 }

--- a/pkg/gowebserver/config.go
+++ b/pkg/gowebserver/config.go
@@ -55,7 +55,7 @@ var (
 	forceOverwriteCertFlag      = flag.Bool("https.certificate.forceoverwrite", false, "Force overwrite existing certificates if they already exist.")
 
 	// Monitoring Flags
-	monitoringDebugEndpointFlag = flag.String("monitoring.debugendpoint", "/debug", "URL path prefix for pprof and OpenTelemetry tracez debug endpoints.")
+	monitoringDebugEndpointFlag = flag.String("monitoring.debugendpoint", "", "URL path prefix for pprof and OpenTelemetry tracez debug endpoints. Leave empty to disable these endpoints.")
 	monitoringTraceURIFlag      = flag.String("monitoring.trace.uri", "", "OTLP HTTP endpoint URL for tracing (e.g. http://host:4318).")
 	monitoringMetricsPath       = flag.String("monitoring.metrics.path", "/metrics", "The URL path for exporting server metrics for Prometheus monitoring.")
 

--- a/pkg/gowebserver/config_test.go
+++ b/pkg/gowebserver/config_test.go
@@ -260,7 +260,7 @@ func TestDefaultConfiguration(t *testing.T) {
 			},
 		},
 		Monitoring: Monitoring{
-			DebugEndpoint: "/debug",
+			DebugEndpoint: "",
 			Metrics: Metrics{
 				Enabled: true,
 				Path:    "/metrics",


### PR DESCRIPTION
## Summary
- Write generated TLS private keys with `0600` instead of `0644` so they aren't world-readable to other local users.
- Default `monitoring.debugendpoint` to empty so pprof and OpenTelemetry tracez debug endpoints are not exposed unless an operator explicitly opts in.

## Test plan
- [x] `go test ./pkg/certtool/...` passes
- [x] `go test ./pkg/gowebserver/...` passes (config_test.go updated for new default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)