### PR TITLE
Reduce unnecessary allocations in rich view, upload, and filename sanitizing

### DIFF
--- a/pkg/gowebserver/richview.go
+++ b/pkg/gowebserver/richview.go
@@ -163,9 +163,10 @@ func (h *richViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Detect language.
+	contentStr := string(content)
 	lexer := lexers.Match(fileName)
 	if lexer == nil {
-		lexer = lexers.Analyse(string(content))
+		lexer = lexers.Analyse(contentStr)
 	}
 	if lexer == nil {
 		lexer = lexers.Fallback
@@ -180,7 +181,7 @@ func (h *richViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	iterator, err := lexer.Tokenise(nil, string(content))
+	iterator, err := lexer.Tokenise(nil, contentStr)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/pkg/gowebserver/upload.go
+++ b/pkg/gowebserver/upload.go
@@ -20,6 +20,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"io"
 	"net/http"
 	"os"
@@ -51,6 +52,7 @@ type uploadHTTPHandler struct {
 	uploadDirectory    string
 	uploadedBytesTotal metric.Int64Counter
 	uploadedFilesTotal metric.Int64Counter
+	tmpl               *template.Template
 }
 
 type uploadResponse struct {
@@ -82,8 +84,8 @@ func (uh *uploadHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			ApplicationVersion string
 		}{uh.uploadHTTPPath, token, uploadFileFormName, version}
 
-		if err := executeTemplate(uploadHTML, params, w); err != nil {
-			logger.With("error", err).Error("cannot parse upload.html template.")
+		if err := uh.tmpl.Execute(w, params); err != nil {
+			logger.With("error", err).Error("cannot execute upload.html template.")
 		}
 	} else {
 		var resp uploadResponse
@@ -156,12 +158,17 @@ func newUploadHandler(mc *monitoringContext, uploadHTTPPath string, uploadDirect
 	if err != nil {
 		return nil, err
 	}
+	tmpl, err := createTemplate(uploadHTML)
+	if err != nil {
+		return nil, err
+	}
 	return &uploadHTTPHandler{
 		tp:                 mc.getTraceProvider(),
 		uploadHTTPPath:     uploadHTTPPath,
 		uploadDirectory:    uploadDirectory,
 		uploadedBytesTotal: uploadedBytesTotal,
 		uploadedFilesTotal: uploadedFilesTotal,
+		tmpl:               tmpl,
 	}, nil
 }
 

--- a/pkg/gowebserver/util.go
+++ b/pkg/gowebserver/util.go
@@ -169,14 +169,15 @@ func ensureDirs(fileName string) error {
 
 func sanitizeFileName(fileName string) string {
 	name := strings.ReplaceAll(filepath.Clean(fileName), "..", ".")
-	sanitized := ""
+	var sanitized strings.Builder
+	sanitized.Grow(len(name))
 	for _, r := range name {
 		if _, ok := validChars[r]; ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') || ('0' <= r && r <= '9') || ok {
-			sanitized = sanitized + string(r)
+			sanitized.WriteRune(r)
 		}
 	}
 
-	parts := strings.Split(strings.ReplaceAll(sanitized, "\\", "/"), "/")
+	parts := strings.Split(strings.ReplaceAll(sanitized.String(), "\\", "/"), "/")
 	sanitizedParts := []string{}
 	for _, part := range parts {
 		if strings.ReplaceAll(part, ".", "") != "" {


### PR DESCRIPTION
## Summary
- richview: avoid converting up to 10MB of file content to a string twice when detecting the language for files chroma can't match by name
- upload: parse the upload page template once at handler construction instead of re-parsing it on every GET request
- sanitizeFileName: build the sanitized filename with `strings.Builder` instead of O(n²) string concatenation

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./pkg/... ./internal/...` (all pass)