### PR TITLE
Fix rich-view links breaking for filenames containing '#'

### DIFF
--- a/pkg/gowebserver/richview.go
+++ b/pkg/gowebserver/richview.go
@@ -97,9 +97,9 @@ func (h *richViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filePath := cleanPath(strings.TrimPrefix(r.URL.Path, "/"))
+	fsPath := cleanPath(strings.TrimPrefix(r.URL.Path, "/"))
 
-	f, err := h.baseFS.Open(filePath)
+	f, err := h.baseFS.Open(fsPath)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -113,7 +113,7 @@ func (h *richViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if stat.IsDir() {
-		http.Redirect(w, r, r.URL.Path, http.StatusFound)
+		http.Redirect(w, r, encodeURLPath(r.URL.Path), http.StatusFound)
 		return
 	}
 
@@ -124,16 +124,18 @@ func (h *richViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fileName := path.Base(r.URL.Path)
-	rawURL := r.URL.Path
+	filePath := encodeURLPath(r.URL.Path)
+	rawURL := filePath
 	parentPath := path.Dir(r.URL.Path)
 	if !strings.HasSuffix(parentPath, "/") {
 		parentPath += "/"
 	}
+	parentPath = encodeURLPath(parentPath)
 
 	if len(content) > richViewMaxFileSize {
 		report := &RichViewReport{
 			FileName:           fileName,
-			FilePath:           r.URL.Path,
+			FilePath:           filePath,
 			ParentPath:         parentPath,
 			RawURL:             rawURL,
 			ApplicationVersion: version,
@@ -199,7 +201,7 @@ func (h *richViewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	report := &RichViewReport{
 		FileName:           fileName,
-		FilePath:           r.URL.Path,
+		FilePath:           filePath,
 		ParentPath:         parentPath,
 		RawURL:             rawURL,
 		Language:           language,

--- a/pkg/gowebserver/richview_test.go
+++ b/pkg/gowebserver/richview_test.go
@@ -159,6 +159,28 @@ func TestRichViewHandler_ThemeOverride(t *testing.T) {
 	}
 }
 
+func TestRichViewHandler_HashInFileName(t *testing.T) {
+	h := makeRichViewHandler(t, map[string][]byte{
+		"weird#1.txt": []byte("hello world\n"),
+	})
+
+	req := httptest.NewRequest("GET", "/placeholder?view=rich", nil)
+	req.URL.Path = "/weird#1.txt"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, `"/weird#1.txt"`) {
+		t.Errorf("links must not contain a literal '#', browsers treat it as a fragment separator: %q", body)
+	}
+	if !strings.Contains(body, "/weird%231.txt") {
+		t.Errorf("expected escaped path '/weird%%231.txt' in body, got: %q", body[:min(600, len(body))])
+	}
+}
+
 func TestRichViewHandler_InvalidTheme(t *testing.T) {
 	h := makeRichViewHandler(t, map[string][]byte{
 		"hello.go": []byte("package main\n"),

--- a/pkg/gowebserver/util.go
+++ b/pkg/gowebserver/util.go
@@ -274,3 +274,12 @@ func stepEnd(val int, step int, max int) bool {
 func urlEncode(u string) string {
 	return url.PathEscape(u)
 }
+
+// encodeURLPath percent-encodes the given URL path so that characters with
+// special meaning in URLs (such as '#', '?', and '%') are preserved as part
+// of the path instead of being interpreted as the start of a fragment or
+// query string when used in an href/Location value. Path separators ('/')
+// are preserved.
+func encodeURLPath(p string) string {
+	return (&url.URL{Path: p}).EscapedPath()
+}


### PR DESCRIPTION
## Summary
- Fixed rich-view (`?view=rich`) links (Raw/Download/Back, theme picker) that broke for filenames containing `#`, since `html/template` doesn't percent-encode `#` in URL attributes and browsers treat it as a fragment separator.
- Added `encodeURLPath()` in `util.go`, which uses `url.URL.EscapedPath()` to percent-encode reserved characters like `#` while preserving `/` separators.
- Applied it to `FilePath`, `RawURL`, `ParentPath`, and the directory redirect target in `richview.go`.

## Test plan
- [x] Added `TestRichViewHandler_HashInFileName` covering a file named `weird#1.txt`, asserting the rendered links use `/weird%231.txt` instead of a literal `#`.
- [x] `go build ./...` and `go vet ./...` pass.
- [x] `go test ./...` passes (all packages).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>