### PR TITLE
Fix flaky TestCustomIndex on Windows from leaked archive file handles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	facette.io/natsort v0.0.0-20181210072756-2cd4dd1e2dcb
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/cloudfra/certtool v0.4.1
-	github.com/cloudfra/ufs v0.9.3
+	github.com/cloudfra/ufs v0.9.6-0.20260716011423-36d722485fc7
 	github.com/dustin/go-humanize v1.0.1
 	github.com/google/go-cmp v0.7.0
 	github.com/jeremyje/gomain v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64
 github.com/cloudflare/circl v1.6.4/go.mod h1:YxarevkLlbaHuWsxG6vmYNWBEsSp4pnp7j+4VljMavY=
 github.com/cloudfra/certtool v0.4.1 h1:TdugAWI8EFv7Ae6rfgkFAwvYfAWgTtEHU5NWdYnijSQ=
 github.com/cloudfra/certtool v0.4.1/go.mod h1:nhttozFoMaZ7qbZ0hLd0u2pZ7OR/Xu9zYq5Z/sLyXEE=
-github.com/cloudfra/ufs v0.9.3 h1:ynzi+JjTMNdMzxoMyspKwe7iRx66kocyZI59EznW0mw=
-github.com/cloudfra/ufs v0.9.3/go.mod h1:KA2eUQi8bUOxqAx+9ouGyNPmYE0AXZ5ac3946RJEX+Y=
+github.com/cloudfra/ufs v0.9.6-0.20260716011423-36d722485fc7 h1:w6DiR3/ns3CNDfmtMlgQ6Uhn2enWoWFH0nJ6uYkOE1s=
+github.com/cloudfra/ufs v0.9.6-0.20260716011423-36d722485fc7/go.mod h1:8NQVz35do7NgZFX2sNIzeLCyZvPynrMVizpREpRdIbI=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=

--- a/pkg/gowebserver/customindex.go
+++ b/pkg/gowebserver/customindex.go
@@ -184,6 +184,7 @@ func tryListDir(fsys fs.FS, path string) {
 		zap.S().With("path", path).With(zap.Error(err)).Warn("failed to open file")
 		return
 	}
+	defer f.Close()
 	if dirList, ok := f.(fs.ReadDirFile); ok {
 		dirs, err := dirList.ReadDir(-1)
 		if err != nil {


### PR DESCRIPTION
TestCustomIndex intermittently failed on Windows during t.TempDir() cleanup with "used by another process" errors on archive-nested.zip.

Two leaks contributed:
- tryListDir() opened a file purely for debug logging on every request and never closed it.
- github.com/cloudfra/ufs v0.9.3 didn't close the file opened when mounting a nested archive-within-an-archive; fixed upstream in v0.9.5.

Bumping to a newer ufs commit (see cloudfra/ufs#fix/archive-directory-open-leak) also works around a leak in github.com/mholt/archives, which drops a freshly opened os.File handle whenever a directory inside a mounted archive is opened, relying on GC finalization to ever close it. That's a coin flip against Windows' TempDir cleanup, which is what made this test flaky rather than a hard failure.